### PR TITLE
chore: workaround vite package build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,8 @@
       "acorn@8.12.0": "patches/acorn@8.12.0.patch",
       "chokidar@3.6.0": "patches/chokidar@3.6.0.patch",
       "http-proxy@1.18.1": "patches/http-proxy@1.18.1.patch",
-      "sirv@2.0.4": "patches/sirv@2.0.4.patch"
+      "sirv@2.0.4": "patches/sirv@2.0.4.patch",
+      "rolldown@0.10.5": "patches/rolldown@0.10.5.patch"
     },
     "peerDependencyRules": {
       "allowedVersions": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
       "chokidar@3.6.0": "patches/chokidar@3.6.0.patch",
       "http-proxy@1.18.1": "patches/http-proxy@1.18.1.patch",
       "sirv@2.0.4": "patches/sirv@2.0.4.patch",
-      "rolldown@0.10.5": "patches/rolldown@0.10.5.patch"
+      "rolldown@0.12.1": "patches/rolldown@0.12.1.patch"
     },
     "peerDependencyRules": {
       "allowedVersions": {

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -88,7 +88,7 @@
     "esbuild": "^0.21.3",
     "postcss": "^8.4.39",
     "rollup": "^4.13.0",
-    "rolldown": "^0.10.5"
+    "rolldown": "^0.12.1"
   },
   "optionalDependencies": {
     "fsevents": "~2.3.3"

--- a/packages/vite/rollup.dts.config.ts
+++ b/packages/vite/rollup.dts.config.ts
@@ -97,7 +97,7 @@ function patchTypes(): Plugin {
         validateRuntimeChunk.call(this, chunk)
       } else {
         validateChunkImports.call(this, chunk)
-        code = replaceConfusingTypeNames.call(this, code, chunk)
+        if (0) code = replaceConfusingTypeNames.call(this, code, chunk)
         code = stripInternalTypes.call(this, code, chunk)
         code = cleanUnnecessaryComments(code)
       }

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -24,12 +24,13 @@ import {
   tryStatSync,
   unique,
 } from '../utils'
-import {
-  transformWithEsbuild,
-} from '../plugins/esbuild'
+import { transformWithEsbuild } from '../plugins/esbuild'
 import { ESBUILD_MODULES_TARGET, METADATA_FILENAME } from '../constants'
 import { isWindows } from '../../shared/utils'
-import { rolldownCjsExternalPlugin, rolldownDepPlugin } from './rolldownDepPlugin'
+import {
+  rolldownCjsExternalPlugin,
+  rolldownDepPlugin,
+} from './rolldownDepPlugin'
 import { scanImports } from './scan'
 import { createOptimizeDepsIncludeResolver, expandGlobIds } from './resolve'
 export {
@@ -617,8 +618,7 @@ export function runOptimizeDeps(
             if (chunk.isEntry) {
               // One chunk maybe corresponding multiply entry
               const deps = Object.values(depsInfo).filter(
-                (d) =>
-                  d.src === chunk.facadeModuleId!,
+                (d) => d.src === chunk.facadeModuleId!,
               )
               for (const { exportsData, file, id, ...info } of deps) {
                 addOptimizedDepInfo(metadata, 'optimized', {
@@ -810,7 +810,7 @@ async function prepareRolldownOptimizerRun(
       resolve: {
         mainFields: ['module', 'main'],
         aliasFields: [['browser']],
-        extensions: ['.js', '.css']
+        extensions: ['.js', '.css'],
       },
       ...rollupOptions,
     })
@@ -820,7 +820,8 @@ async function prepareRolldownOptimizerRun(
       dir: processingCacheDir,
       banner:
         platform === 'node'
-          ? (chunk) =>
+          ? // TODO: use async to workaround https://github.com/rolldown/rolldown/issues/1655
+            async (chunk) =>
               chunk.fileName.endsWith('.js')
                 ? `import { createRequire } from 'module';const require = createRequire(import.meta.url);`
                 : ''
@@ -1037,13 +1038,16 @@ function stringifyDepsOptimizerMetadata(
               file,
               fileHash,
               needsInterop,
-              isDynamicEntry
+              isDynamicEntry,
             },
           ],
         ),
       ),
       chunks: Object.fromEntries(
-        Object.values(chunks).map(({ id, file, isDynamicEntry }) => [id, { file, isDynamicEntry }]),
+        Object.values(chunks).map(({ id, file, isDynamicEntry }) => [
+          id,
+          { file, isDynamicEntry },
+        ]),
       ),
     },
     (key: string, value: string) => {
@@ -1075,11 +1079,11 @@ export async function extractExportsData(
     const rolldownBuild = await rolldown.rolldown({
       ...rollupOptions,
       input: [filePath],
-    });
+    })
     const result = await rolldownBuild.generate({
       ...rollupOptions.output,
       format: 'esm',
-    });
+    })
     const [, exports, , hasModuleSyntax] = parse(result.output[0].code)
     return {
       hasModuleSyntax,

--- a/packages/vite/src/node/optimizer/scan.ts
+++ b/packages/vite/src/node/optimizer/scan.ts
@@ -6,7 +6,7 @@ import glob from 'fast-glob'
 import type { Plugin } from 'rolldown'
 import * as rolldown from 'rolldown'
 import type { Loader } from 'esbuild'
-import  { transform } from 'esbuild'
+import { transform } from 'esbuild'
 import colors from 'picocolors'
 import type { ResolvedConfig } from '..'
 import {
@@ -41,6 +41,7 @@ type ResolveIdOptions = Parameters<PluginContainer['resolveId']>[2]
 
 const debug = createDebugger('vite:deps')
 
+// eslint-disable-next-line regexp/no-unused-capturing-group
 const htmlTypesRE = /\.(html|vue|svelte|astro|imba)$/
 
 // A simple regex to detect import sources. This is only used on
@@ -100,15 +101,13 @@ export function scanImports(config: ResolvedConfig): {
       if (!context || scanContext?.cancelled) {
         return { deps: {}, missing: {} }
       }
-      return context
-        .build()
-        .then(() => {
-          return {
-            // Ensure a fixed order so hashes are stable and improve logs
-            deps: orderedDependencies(deps),
-            missing,
-          }
-        })
+      return context.build().then(() => {
+        return {
+          // Ensure a fixed order so hashes are stable and improve logs
+          deps: orderedDependencies(deps),
+          missing,
+        }
+      })
     })
     .catch(async (e) => {
       // if (e.errors && e.message.includes('The build was canceled')) {
@@ -129,7 +128,7 @@ export function scanImports(config: ResolvedConfig): {
       //   })
       //   e.message = prependMessage + msgs.join('\n')
       // } else {
-        e.message = prependMessage + e.message
+      e.message = prependMessage + e.message
       // }
       throw e
     })
@@ -807,10 +806,10 @@ function rolldownScanPlugin(
           content + (loader.startsWith('ts') ? extractImportPaths(content) : '')
 
         const key = `${p}?id=${scriptId++}&loader=${loader}`
-        if (loader !== 'js') {
-          contents = (await transform(contents, { loader })).code
-        }
         if (contents.includes('import.meta.glob')) {
+          if (loader !== 'js') {
+            contents = (await transform(contents, { loader })).code
+          }
           scripts[key] = await doTransformGlobImport(contents, p)
         } else {
           scripts[key] = contents
@@ -1020,11 +1019,10 @@ function rolldownScanPlugin(
 
         const loader = ext as Loader
 
-        if (loader !== 'js') {
-          contents = (await transform(contents, { loader })).code
-        }
-
         if (contents.includes('import.meta.glob')) {
+          if (loader !== 'js') {
+            contents = (await transform(contents, { loader })).code
+          }
           return {
             code: await doTransformGlobImport(contents, id),
           }
@@ -1037,7 +1035,6 @@ function rolldownScanPlugin(
     },
   }
 }
-
 
 /**
  * when using TS + (Vue + `<script setup>`) or Svelte, imports may seem

--- a/patches/rolldown@0.10.5.patch
+++ b/patches/rolldown@0.10.5.patch
@@ -1,0 +1,31 @@
+diff --git a/dist/types/binding.d.ts b/dist/types/binding.d.ts
+index c2eacae598819b8ab09ce9128b7efd53386be4bb..2e1a72825b79a8bbaa2debfdc39fc3b3be535447 100644
+--- a/dist/types/binding.d.ts
++++ b/dist/types/binding.d.ts
+@@ -232,7 +232,7 @@ export interface BindingResolveOptions {
+ }
+ 
+ export interface BindingSourcemap {
+-  inner: string | BindingJSONSourcemap
++  inner: string | BindingJsonSourcemap
+ }
+ 
+ export interface BindingTreeshake {
+@@ -253,4 +253,3 @@ export interface RenderedChunk {
+   imports: Array<string>
+   dynamicImports: Array<string>
+ }
+-
+diff --git a/dist/types/options/normalized-input-options.d.ts b/dist/types/options/normalized-input-options.d.ts
+index 843cc3d53c5d4d13bfd1257373d656be3ac4daaa..9affc6c0bdefd355fa227afe555f43ffeb560941 100644
+--- a/dist/types/options/normalized-input-options.d.ts
++++ b/dist/types/options/normalized-input-options.d.ts
+@@ -2,7 +2,7 @@ import type { LogLevelOption, RollupLog, NormalizedInputOptions as RollupNormali
+ import type { InputOptions } from './input-options';
+ import type { RolldownPlugin } from '../plugin';
+ import type { LogLevel } from '../log/logging';
+-import { NormalizedTreeshakingOptions } from '../../src/treeshake';
++import { NormalizedTreeshakingOptions } from '../treeshake';
+ export interface NormalizedInputOptions extends InputOptions {
+     input: RollupNormalizedInputOptions['input'];
+     plugins: RolldownPlugin[];

--- a/patches/rolldown@0.12.1.patch
+++ b/patches/rolldown@0.12.1.patch
@@ -1,0 +1,31 @@
+diff --git a/dist/types/binding.d.ts b/dist/types/binding.d.ts
+index a6a5fc5cc68c7151e2ba8ef40304f635adefaa41..88da140d22bb586721f07947c3497d0cd24f5b0b 100644
+--- a/dist/types/binding.d.ts
++++ b/dist/types/binding.d.ts
+@@ -247,7 +247,7 @@ export interface BindingResolveOptions {
+ }
+ 
+ export interface BindingSourcemap {
+-  inner: string | BindingJSONSourcemap
++  inner: string | BindingJsonSourcemap
+ }
+ 
+ export interface BindingTreeshake {
+@@ -334,4 +334,3 @@ export interface TypeScriptBindingOptions {
+   allowNamespaces?: boolean
+   allowDeclareFields?: boolean
+ }
+-
+diff --git a/dist/types/options/normalized-input-options.d.ts b/dist/types/options/normalized-input-options.d.ts
+index 43794f69c9036db22c58200ddf812b128ff2d821..d4ba99ef6d402e506e41b00e10ec26a6bf71902d 100644
+--- a/dist/types/options/normalized-input-options.d.ts
++++ b/dist/types/options/normalized-input-options.d.ts
+@@ -2,7 +2,7 @@ import type { LogLevelOption, RollupLog, NormalizedInputOptions as RollupNormali
+ import type { InputOptions } from './input-options';
+ import type { RolldownPlugin } from '../plugin';
+ import type { LogLevel } from '../log/logging';
+-import { NormalizedTreeshakingOptions } from '../../src/treeshake';
++import { NormalizedTreeshakingOptions } from '../treeshake';
+ export interface NormalizedInputOptions extends Omit<InputOptions, 'treeshake'> {
+     input: RollupNormalizedInputOptions['input'];
+     plugins: RolldownPlugin[];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ patchedDependencies:
   http-proxy@1.18.1:
     hash: qqiqxx62zlcu62nljjmhlvexni
     path: patches/http-proxy@1.18.1.patch
+  rolldown@0.10.5:
+    hash: ln72metpgkqigpsuuo4ap6taba
+    path: patches/rolldown@0.10.5.patch
   sirv@2.0.4:
     hash: amdes53ifqfntejkflpaq5ifce
     path: patches/sirv@2.0.4.patch
@@ -235,7 +238,7 @@ importers:
         version: 8.4.39
       rolldown:
         specifier: ^0.10.5
-        version: 0.10.5
+        version: 0.10.5(patch_hash=ln72metpgkqigpsuuo4ap6taba)
       rollup:
         specifier: ^4.13.0
         version: 4.13.0
@@ -11751,7 +11754,7 @@ snapshots:
     dependencies:
       glob: 10.3.10
 
-  rolldown@0.10.5:
+  rolldown@0.10.5(patch_hash=ln72metpgkqigpsuuo4ap6taba):
     dependencies:
       citty: 0.1.6
       colorette: 2.0.20

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,9 @@ patchedDependencies:
   http-proxy@1.18.1:
     hash: qqiqxx62zlcu62nljjmhlvexni
     path: patches/http-proxy@1.18.1.patch
-  rolldown@0.10.5:
-    hash: ln72metpgkqigpsuuo4ap6taba
-    path: patches/rolldown@0.10.5.patch
+  rolldown@0.12.1:
+    hash: hr7d2oyaabira3jldey4m7addu
+    path: patches/rolldown@0.12.1.patch
   sirv@2.0.4:
     hash: amdes53ifqfntejkflpaq5ifce
     path: patches/sirv@2.0.4.patch
@@ -237,8 +237,8 @@ importers:
         specifier: ^8.4.39
         version: 8.4.39
       rolldown:
-        specifier: ^0.10.5
-        version: 0.10.5(patch_hash=ln72metpgkqigpsuuo4ap6taba)
+        specifier: ^0.12.1
+        version: 0.12.1(patch_hash=hr7d2oyaabira3jldey4m7addu)
       rollup:
         specifier: ^4.13.0
         version: 4.13.0
@@ -2862,58 +2862,58 @@ packages:
   '@polka/url@1.0.0-next.24':
     resolution: {integrity: sha512-2LuNTFBIO0m7kKIQvvPHN6UE63VjpmL9rnEEaOOaiSPbZK+zUOYIzBAWcED+3XYzhYsd/0mD57VdxAEqqV52CQ==}
 
-  '@rolldown/binding-darwin-arm64@0.10.5':
-    resolution: {integrity: sha512-hCwEjzDOBOA+vvFjcoSWZBTilcTvPs/zMjPNmLKZoZg58TNK5p3StZbrIuPaklhYT4j0X5emyoU3Vs0wswzYqg==}
+  '@rolldown/binding-darwin-arm64@0.12.1':
+    resolution: {integrity: sha512-NWtxYWEb7Nd40WQHW/Fp3OolqxkwmfL/OJ2GWPOSBEmE7c6/iEgLROy+enkGkBKXdF6epsc+UUQGN5Mp03vaFw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@0.10.5':
-    resolution: {integrity: sha512-yRtnTyIyXYH7dQgtZoLinRqO+o/ROTPdWLcMHvRK8o+Rx0G4UC2KXapiq+SpQEEZwMMPnMGrDJ++1W+gzsJLAw==}
+  '@rolldown/binding-darwin-x64@0.12.1':
+    resolution: {integrity: sha512-9MVhdXaCUHBpuTRZWGrB4ptUd2cYkg56KdcHL6fLL9LtMnCRmsJ5s2QNIOyzF3lgDNt3ic3iHcKoPex0TNRtpg==}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-linux-arm-gnueabihf@0.10.5':
-    resolution: {integrity: sha512-pT9+xKS7uUvh4LGEbRkM7NuYRrTnT0M+QxORVN0BFXBIMCWVh/g5dL/86/P9POjN0wjfJCt7sD1XTq2csC17Bw==}
+  '@rolldown/binding-linux-arm-gnueabihf@0.12.1':
+    resolution: {integrity: sha512-IS8zyitSUquGjGFK7T5VQwhkyWIsJ/kVj9fKKBg5+ejZiMCkUFbBj03Cm6WDyIBakLeA2Wjgwuvy1hSzsrKPJw==}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@0.10.5':
-    resolution: {integrity: sha512-yjwqwS86v61/qIOeoTb13roNYsw9BKhVHJ8gPrAR/CCSRa93G1SoDGxzlZTpZL1zF/8GnegGy4vU6zZ4RMJqsQ==}
+  '@rolldown/binding-linux-arm64-gnu@0.12.1':
+    resolution: {integrity: sha512-zbO53A0NXGvigsNXGBnxc1LtLynqGR31dLSqF8LT4/vdJHYJOK5nKr9bzKErELeYaseZfA/jV8+whImB0F/3ow==}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-musl@0.10.5':
-    resolution: {integrity: sha512-/C+r30Kl4jIpXS7/akg9YnhVBQxY4jiz0GLc0UpCAt7oaoAhgZXCWpqGgPv4jpvGFYP+bp91kCqS0C3dOnU+mA==}
+  '@rolldown/binding-linux-arm64-musl@0.12.1':
+    resolution: {integrity: sha512-1V7ms7bG8T5Ob0jrIl0AZOU6UQxC/QDvqo9+ZUTEI5vVBYZPvTEAzEpYXKAn/pVPKwmh80epsaRL5D3Rc3WNWQ==}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-gnu@0.10.5':
-    resolution: {integrity: sha512-kOvKZgoXjfWtgHIz8U4/rp1WfSpJMpgRuAJ5AnMhqEfUKXCFkbZsCy7oggdo7u2NXonO3sQmfov+YKO3ec5Hsg==}
+  '@rolldown/binding-linux-x64-gnu@0.12.1':
+    resolution: {integrity: sha512-rTFRH8ezlStxFvB33F4DodoFAIsGgCv0wRbs9965duMqWSYMlMHg4yFLOW6GNf1t86V7reG59rGPNbWn2evyVA==}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-musl@0.10.5':
-    resolution: {integrity: sha512-dT1HmEJfaiy1ZNsIuNLvkOo6mG0jL4d8gmR0ftk0BwKXH1M8Wnia3fP8k4nn6K3cwGHTBkPObLk/O++9Bt23Vw==}
+  '@rolldown/binding-linux-x64-musl@0.12.1':
+    resolution: {integrity: sha512-fwIv3777FBj3Wztc59B7/7mVW/Fm38keslyr6Op8UVPQy604qHYaztzQYjBzZcbxCTeJKdXWoNz/3ddn53+zeA==}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-wasm32-wasi@0.10.5':
-    resolution: {integrity: sha512-ieDGFO6GXeayxWRxVvAl8H75oQXLkASZ7R84qcq/ue5EY36Zst8KMAcNU2Pvpm0z0/6IDwSMAxF1nJPhQWQzqw==}
+  '@rolldown/binding-wasm32-wasi@0.12.1':
+    resolution: {integrity: sha512-AzbfEXik1+t+guVIFQJ92O/W5jyq/+BFsXSlb5rYL7ZzxOjLEXL0IRizY/rIqxF43KnsO7lf51qKH6g+E5VRNA==}
     engines: {node: '>=14.21.3'}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@0.10.5':
-    resolution: {integrity: sha512-EPZTG0WXWimc/LaLHmEpVZ1j7eX+Zrrpg/Sx/pEjiDRCYr0ztdKRM06HUsk4Bqtd/6HXIJOWWLSWwlxXEuOAeg==}
+  '@rolldown/binding-win32-arm64-msvc@0.12.1':
+    resolution: {integrity: sha512-U//wRnkk4Bm8VjRD1hWkpxO36M4ZXekBxciNLZbW7wKGIs1zkMBc77nA93iOQZgbE6a1JvJQT4/aPoqNg0JfpA==}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-ia32-msvc@0.10.5':
-    resolution: {integrity: sha512-If+pP+v7ccXrp6vg5Gq6V8+ATn+RSl7eDndOj3LGNCOfoPbgBGZNwsNS9ZE1VOsj99qQgOtoc9JwgP333TR81g==}
+  '@rolldown/binding-win32-ia32-msvc@0.12.1':
+    resolution: {integrity: sha512-79oEmO35sQXl4nnd9WdZLbxcSCtCrUO9zMr75S49Ol+aiPOCgOx9ObyilLO8sWYFX56VFow3271JKTeY6b4eXQ==}
     cpu: [ia32]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@0.10.5':
-    resolution: {integrity: sha512-NCPYa5kEBkolWa9c6zf6FDq77bdmdm9u4ydRvWdOiC4xDKW/8bSyxmW6EvAimkOWkDvNQjzNaWF2nO2ywm6ZnQ==}
+  '@rolldown/binding-win32-x64-msvc@0.12.1':
+    resolution: {integrity: sha512-zjGS/TgiwPNA3Wkadww9EMQ/1DHjj2J4KsPOmew5y8jYydtMM3iOYUlymbPFuVd5SL7FP6nlHSGWJL+d4na4bA==}
     cpu: [x64]
     os: [win32]
 
@@ -4039,9 +4039,6 @@ packages:
 
   citty@0.1.4:
     resolution: {integrity: sha512-Q3bK1huLxzQrvj7hImJ7Z1vKYJRPQCDnd0EjXfHMidcjecGOMuLrmuQmtWmFkuKLcMThlGh1yCKG8IEc6VeNXQ==}
-
-  citty@0.1.6:
-    resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
 
   cli-cursor@4.0.0:
     resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
@@ -5229,9 +5226,6 @@ packages:
     resolution: {integrity: sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==}
     engines: {node: '>=14'}
 
-  locate-character@3.0.0:
-    resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
-
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -6124,8 +6118,8 @@ packages:
     engines: {node: '>=14.18'}
     hasBin: true
 
-  rolldown@0.10.5:
-    resolution: {integrity: sha512-ZQrbits9lGYGqlOlySqsHGcIudVcVWmtWXMfyWCwF21O0TKLe29XiK8xDFdxihj+4Wmn9bVcm0/z4mOUpi1/2Q==}
+  rolldown@0.12.1:
+    resolution: {integrity: sha512-KHcX/FPdkCmJX3j2C6VaSd2pRmleQ720rtOAL5IciP2oCQ8+DKS7G/UAezV+bOLExXwB4GR8M+hGjE2XxzFV0g==}
     hasBin: true
 
   rollup-plugin-dts@6.0.2:
@@ -8220,39 +8214,39 @@ snapshots:
 
   '@polka/url@1.0.0-next.24': {}
 
-  '@rolldown/binding-darwin-arm64@0.10.5':
+  '@rolldown/binding-darwin-arm64@0.12.1':
     optional: true
 
-  '@rolldown/binding-darwin-x64@0.10.5':
+  '@rolldown/binding-darwin-x64@0.12.1':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@0.10.5':
+  '@rolldown/binding-linux-arm-gnueabihf@0.12.1':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@0.10.5':
+  '@rolldown/binding-linux-arm64-gnu@0.12.1':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@0.10.5':
+  '@rolldown/binding-linux-arm64-musl@0.12.1':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@0.10.5':
+  '@rolldown/binding-linux-x64-gnu@0.12.1':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@0.10.5':
+  '@rolldown/binding-linux-x64-musl@0.12.1':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@0.10.5':
+  '@rolldown/binding-wasm32-wasi@0.12.1':
     dependencies:
       '@napi-rs/wasm-runtime': 0.2.4
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@0.10.5':
+  '@rolldown/binding-win32-arm64-msvc@0.12.1':
     optional: true
 
-  '@rolldown/binding-win32-ia32-msvc@0.10.5':
+  '@rolldown/binding-win32-ia32-msvc@0.12.1':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@0.10.5':
+  '@rolldown/binding-win32-x64-msvc@0.12.1':
     optional: true
 
   '@rollup/plugin-alias@5.0.0(rollup@3.29.4)':
@@ -9439,10 +9433,6 @@ snapshots:
   chownr@2.0.0: {}
 
   citty@0.1.4:
-    dependencies:
-      consola: 3.2.3
-
-  citty@0.1.6:
     dependencies:
       consola: 3.2.3
 
@@ -10732,8 +10722,6 @@ snapshots:
       mlly: 1.7.1
       pkg-types: 1.0.3
 
-  locate-character@3.0.0: {}
-
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -11754,26 +11742,21 @@ snapshots:
     dependencies:
       glob: 10.3.10
 
-  rolldown@0.10.5(patch_hash=ln72metpgkqigpsuuo4ap6taba):
+  rolldown@0.12.1(patch_hash=hr7d2oyaabira3jldey4m7addu):
     dependencies:
-      citty: 0.1.6
-      colorette: 2.0.20
-      consola: 3.2.3
-      locate-character: 3.0.0
-      mri: 1.2.0
       zod: 3.23.8
     optionalDependencies:
-      '@rolldown/binding-darwin-arm64': 0.10.5
-      '@rolldown/binding-darwin-x64': 0.10.5
-      '@rolldown/binding-linux-arm-gnueabihf': 0.10.5
-      '@rolldown/binding-linux-arm64-gnu': 0.10.5
-      '@rolldown/binding-linux-arm64-musl': 0.10.5
-      '@rolldown/binding-linux-x64-gnu': 0.10.5
-      '@rolldown/binding-linux-x64-musl': 0.10.5
-      '@rolldown/binding-wasm32-wasi': 0.10.5
-      '@rolldown/binding-win32-arm64-msvc': 0.10.5
-      '@rolldown/binding-win32-ia32-msvc': 0.10.5
-      '@rolldown/binding-win32-x64-msvc': 0.10.5
+      '@rolldown/binding-darwin-arm64': 0.12.1
+      '@rolldown/binding-darwin-x64': 0.12.1
+      '@rolldown/binding-linux-arm-gnueabihf': 0.12.1
+      '@rolldown/binding-linux-arm64-gnu': 0.12.1
+      '@rolldown/binding-linux-arm64-musl': 0.12.1
+      '@rolldown/binding-linux-x64-gnu': 0.12.1
+      '@rolldown/binding-linux-x64-musl': 0.12.1
+      '@rolldown/binding-wasm32-wasi': 0.12.1
+      '@rolldown/binding-win32-arm64-msvc': 0.12.1
+      '@rolldown/binding-win32-ia32-msvc': 0.12.1
+      '@rolldown/binding-win32-x64-msvc': 0.12.1
 
   rollup-plugin-dts@6.0.2(rollup@3.29.4)(typescript@5.2.2):
     dependencies:


### PR DESCRIPTION
### Description

In addition to https://github.com/rolldown/rolldown/pull/1642, it looks like `replaceConfusingTypeNames` is messing with vite package build. I haven't checked the error in a detail, but maybe it's okay to skip it for starter?

I temporary included a patch for `binding.d.ts` type error in the PR to verify `pnpm build` succeeds.