### PR TITLE
fix: externalize `optimizeDeps.exclude` via `rolldownCjsExternalPlugin` (fix `test-serve playground/external`)

### DIFF
--- a/packages/vite/rollup.dts.config.ts
+++ b/packages/vite/rollup.dts.config.ts
@@ -97,7 +97,7 @@ function patchTypes(): Plugin {
         validateRuntimeChunk.call(this, chunk)
       } else {
         validateChunkImports.call(this, chunk)
-        code = replaceConfusingTypeNames.call(this, code, chunk)
+        if (0) code = replaceConfusingTypeNames.call(this, code, chunk)
         code = stripInternalTypes.call(this, code, chunk)
         code = cleanUnnecessaryComments(code)
       }

--- a/packages/vite/src/node/optimizer/index.ts
+++ b/packages/vite/src/node/optimizer/index.ts
@@ -804,7 +804,7 @@ async function prepareRolldownOptimizerRun(
   async function build() {
     const bundle = await rolldown.rolldown({
       input: Object.keys(flatIdDeps),
-      external,
+      // external,
       logLevel: 'warn',
       plugins,
       resolve: {


### PR DESCRIPTION
### Description

Currently `optimizeDeps.exclude` is externalized at the config level `rolldown.rolldown({ external: ... })` and it looks like `rolldownCjsExternalPlugin` doesn't have a chance to fixup cjs external. This manifests as test failures in `playground/external`.

Since `rolldownCjsExternalPlugin` also handles non-cjs external, I simply removed rolldown's `external` config and it looks like tests are passing.

Only the last commit https://github.com/rolldown/vite/pull/31/commits/5edc81d9aaab04b226adc2fbbdf5b017b01ef7cd is the actual fix and first commits are the same one from https://github.com/rolldown/vite/pull/28.