### PR TITLE
chore: silence vite package dts build error

### DIFF
--- a/packages/vite/rollup.dts.config.ts
+++ b/packages/vite/rollup.dts.config.ts
@@ -97,7 +97,7 @@ function patchTypes(): Plugin {
         validateRuntimeChunk.call(this, chunk)
       } else {
         validateChunkImports.call(this, chunk)
-        code = replaceConfusingTypeNames.call(this, code, chunk)
+        if (0) code = replaceConfusingTypeNames.call(this, code, chunk)
         code = stripInternalTypes.call(this, code, chunk)
         code = cleanUnnecessaryComments(code)
       }


### PR DESCRIPTION
### Description

Reopening https://github.com/rolldown/vite/pull/28 to just workaround this part `replaceConfusingTypeNames`. This should hopefully make package build pass, so CI can check `test-serve`.