### PR TITLE
feat: using oxc resolver

### DIFF
--- a/packages/vite/LICENSE.md
+++ b/packages/vite/LICENSE.md
@@ -471,6 +471,35 @@ Repository: lukeed/polka
 
 ---------------------------------------
 
+## @rollup/plugin-alias
+License: MIT
+By: Johannes Stein
+Repository: rollup/plugins
+
+> The MIT License (MIT)
+> 
+> Copyright (c) 2019 RollupJS Plugin Contributors (https://github.com/rollup/plugins/graphs/contributors)
+> 
+> Permission is hereby granted, free of charge, to any person obtaining a copy
+> of this software and associated documentation files (the "Software"), to deal
+> in the Software without restriction, including without limitation the rights
+> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+> copies of the Software, and to permit persons to whom the Software is
+> furnished to do so, subject to the following conditions:
+> 
+> The above copyright notice and this permission notice shall be included in
+> all copies or substantial portions of the Software.
+> 
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+> THE SOFTWARE.
+
+---------------------------------------
+
 ## @rollup/plugin-dynamic-import-vars
 License: MIT
 By: LarsDenBakker

--- a/packages/vite/LICENSE.md
+++ b/packages/vite/LICENSE.md
@@ -471,35 +471,6 @@ Repository: lukeed/polka
 
 ---------------------------------------
 
-## @rollup/plugin-alias
-License: MIT
-By: Johannes Stein
-Repository: rollup/plugins
-
-> The MIT License (MIT)
-> 
-> Copyright (c) 2019 RollupJS Plugin Contributors (https://github.com/rollup/plugins/graphs/contributors)
-> 
-> Permission is hereby granted, free of charge, to any person obtaining a copy
-> of this software and associated documentation files (the "Software"), to deal
-> in the Software without restriction, including without limitation the rights
-> to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-> copies of the Software, and to permit persons to whom the Software is
-> furnished to do so, subject to the following conditions:
-> 
-> The above copyright notice and this permission notice shall be included in
-> all copies or substantial portions of the Software.
-> 
-> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-> IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-> FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-> AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-> LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-> OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-> THE SOFTWARE.
-
----------------------------------------
-
 ## @rollup/plugin-dynamic-import-vars
 License: MIT
 By: LarsDenBakker

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -88,7 +88,8 @@
     "esbuild": "^0.21.3",
     "postcss": "^8.4.41",
     "rollup": "^4.20.0",
-    "rolldown": "0.12.2-snapshot-aa5807f-20240902003235"
+    "rolldown": "0.12.2-snapshot-aa5807f-20240902003235",
+    "oxc-resolver": "1.11.0"
   },
   "optionalDependencies": {
     "fsevents": "~2.3.3"

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -530,6 +530,13 @@ export async function build(
     ssr ? config.plugins.map((p) => injectSsrFlagToHooks(p)) : config.plugins
   ) as Plugin[]
 
+  const alias: Record<string, string> = {}
+  for (const { find, replacement } of config.resolve.alias) {
+    if (typeof find === 'string') {
+      alias[find] = replacement
+    }
+  }
+
   const rollupOptions: RollupOptions = {
     // TODO @underfin preserveEntrySignatures
     // preserveEntrySignatures: ssr
@@ -541,6 +548,13 @@ export async function build(
     ...options.rollupOptions,
     input,
     plugins,
+    resolve: {
+      alias,
+      mainFields: config.resolve.mainFields,
+      conditionNames: config.resolve.conditions,
+      symlinks: config.resolve.preserveSymlinks,
+      extensions: config.resolve.extensions,
+    },
     external: options.rollupOptions?.external,
     onwarn(warning, warn) {
       onRollupWarning(warning, warn, config)

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -7,7 +7,7 @@ import { performance } from 'node:perf_hooks'
 import { createRequire } from 'node:module'
 import colors from 'picocolors'
 import type { Alias, AliasOptions } from 'dep-types/alias'
-// import aliasPlugin from '@rollup/plugin-alias'
+import aliasPlugin from '@rollup/plugin-alias'
 import { build } from 'esbuild'
 import type { RollupOptions } from 'rolldown'
 import { withTrailingSlash } from '../shared/utils'
@@ -643,42 +643,42 @@ export async function resolveConfig(
   // create an internal resolver to be used in special scenarios, e.g.
   // optimizer & handling css @imports
   const createResolver: ResolvedConfig['createResolver'] = (options) => {
-    // let aliasContainer: PluginContainer | undefined
+    let aliasContainer: PluginContainer | undefined
     let resolverContainer: PluginContainer | undefined
     return async (id, importer, aliasOnly, ssr) => {
-      // let container: PluginContainer
-      // if (aliasOnly) {
-      //   container =
-      //     aliasContainer ||
-      //     (aliasContainer = await createPluginContainer({
-      //       ...resolved,
-      //       // @ts-expect-error  the aliasPlugin using rollup types
-      //       plugins: [aliasPlugin({ entries: resolved.resolve.alias })],
-      //     }))
-      // } else {
-      const container: PluginContainer | undefined =
-        resolverContainer ||
-        (resolverContainer = await createPluginContainer({
-          ...resolved,
-          plugins: [
-            //// @ts-expect-error the aliasPlugin using rollup types
-            // aliasPlugin({ entries: resolved.resolve.alias }),
-            resolvePlugin({
-              ...resolved.resolve,
-              root: resolvedRoot,
-              isProduction,
-              isBuild: command === 'build',
-              ssrConfig: resolved.ssr,
-              asSrc: true,
-              preferRelative: false,
-              tryIndex: true,
-              ...options,
-              idOnly: true,
-              fsUtils: getFsUtils(resolved),
-            }),
-          ],
-        }))
-      // }
+      let container: PluginContainer
+      if (aliasOnly) {
+        container =
+          aliasContainer ||
+          (aliasContainer = await createPluginContainer({
+            ...resolved,
+            // @ts-expect-error  the aliasPlugin using rollup types
+            plugins: [aliasPlugin({ entries: resolved.resolve.alias })],
+          }))
+      } else {
+        container =
+          resolverContainer ||
+          (resolverContainer = await createPluginContainer({
+            ...resolved,
+            plugins: [
+              // @ts-expect-error the aliasPlugin using rollup types
+              aliasPlugin({ entries: resolved.resolve.alias }),
+              resolvePlugin({
+                ...resolved.resolve,
+                root: resolvedRoot,
+                isProduction,
+                isBuild: command === 'build',
+                ssrConfig: resolved.ssr,
+                asSrc: true,
+                preferRelative: false,
+                tryIndex: true,
+                ...options,
+                idOnly: true,
+                fsUtils: getFsUtils(resolved),
+              }),
+            ],
+          }))
+      }
       return (
         await container.resolveId(id, importer, {
           ssr,

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -530,13 +530,22 @@ export async function resolveConfig(
 
   checkBadCharactersInPath(resolvedRoot, logger)
 
+  // oxc resolver only support string alias key matching
   const clientAlias = [
     {
-      find: /^\/?@vite\/env/,
+      find: '/@vite/env',
       replacement: path.posix.join(FS_PREFIX, normalizePath(ENV_ENTRY)),
     },
     {
-      find: /^\/?@vite\/client/,
+      find: '@vite/env',
+      replacement: path.posix.join(FS_PREFIX, normalizePath(ENV_ENTRY)),
+    },
+    {
+      find: '/@vite/client',
+      replacement: path.posix.join(FS_PREFIX, normalizePath(CLIENT_ENTRY)),
+    },
+    {
+      find: '@vite/client',
       replacement: path.posix.join(FS_PREFIX, normalizePath(CLIENT_ENTRY)),
     },
   ]

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -7,7 +7,7 @@ import { performance } from 'node:perf_hooks'
 import { createRequire } from 'node:module'
 import colors from 'picocolors'
 import type { Alias, AliasOptions } from 'dep-types/alias'
-import aliasPlugin from '@rollup/plugin-alias'
+// import aliasPlugin from '@rollup/plugin-alias'
 import { build } from 'esbuild'
 import type { RollupOptions } from 'rolldown'
 import { withTrailingSlash } from '../shared/utils'
@@ -637,7 +637,7 @@ export async function resolveConfig(
     // let aliasContainer: PluginContainer | undefined
     let resolverContainer: PluginContainer | undefined
     return async (id, importer, aliasOnly, ssr) => {
-      let container: PluginContainer
+      // let container: PluginContainer
       // if (aliasOnly) {
       //   container =
       //     aliasContainer ||
@@ -647,7 +647,7 @@ export async function resolveConfig(
       //       plugins: [aliasPlugin({ entries: resolved.resolve.alias })],
       //     }))
       // } else {
-      container =
+      const container: PluginContainer | undefined =
         resolverContainer ||
         (resolverContainer = await createPluginContainer({
           ...resolved,

--- a/packages/vite/src/node/config.ts
+++ b/packages/vite/src/node/config.ts
@@ -634,42 +634,42 @@ export async function resolveConfig(
   // create an internal resolver to be used in special scenarios, e.g.
   // optimizer & handling css @imports
   const createResolver: ResolvedConfig['createResolver'] = (options) => {
-    let aliasContainer: PluginContainer | undefined
+    // let aliasContainer: PluginContainer | undefined
     let resolverContainer: PluginContainer | undefined
     return async (id, importer, aliasOnly, ssr) => {
       let container: PluginContainer
-      if (aliasOnly) {
-        container =
-          aliasContainer ||
-          (aliasContainer = await createPluginContainer({
-            ...resolved,
-            // @ts-expect-error  the aliasPlugin using rollup types
-            plugins: [aliasPlugin({ entries: resolved.resolve.alias })],
-          }))
-      } else {
-        container =
-          resolverContainer ||
-          (resolverContainer = await createPluginContainer({
-            ...resolved,
-            plugins: [
-              // @ts-expect-error the aliasPlugin using rollup types
-              aliasPlugin({ entries: resolved.resolve.alias }),
-              resolvePlugin({
-                ...resolved.resolve,
-                root: resolvedRoot,
-                isProduction,
-                isBuild: command === 'build',
-                ssrConfig: resolved.ssr,
-                asSrc: true,
-                preferRelative: false,
-                tryIndex: true,
-                ...options,
-                idOnly: true,
-                fsUtils: getFsUtils(resolved),
-              }),
-            ],
-          }))
-      }
+      // if (aliasOnly) {
+      //   container =
+      //     aliasContainer ||
+      //     (aliasContainer = await createPluginContainer({
+      //       ...resolved,
+      //       // @ts-expect-error  the aliasPlugin using rollup types
+      //       plugins: [aliasPlugin({ entries: resolved.resolve.alias })],
+      //     }))
+      // } else {
+      container =
+        resolverContainer ||
+        (resolverContainer = await createPluginContainer({
+          ...resolved,
+          plugins: [
+            //// @ts-expect-error the aliasPlugin using rollup types
+            // aliasPlugin({ entries: resolved.resolve.alias }),
+            resolvePlugin({
+              ...resolved.resolve,
+              root: resolvedRoot,
+              isProduction,
+              isBuild: command === 'build',
+              ssrConfig: resolved.ssr,
+              asSrc: true,
+              preferRelative: false,
+              tryIndex: true,
+              ...options,
+              idOnly: true,
+              fsUtils: getFsUtils(resolved),
+            }),
+          ],
+        }))
+      // }
       return (
         await container.resolveId(id, importer, {
           ssr,
@@ -1111,6 +1111,7 @@ async function bundleConfigFile(
               id,
               importer,
               {
+                alias: [],
                 root: path.dirname(fileName),
                 isBuild: true,
                 isProduction: true,

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -48,16 +48,18 @@ export async function resolvePlugins(
     isBuild ? metadataPlugin() : null,
     !isWorker ? watchPackageDataPlugin(config.packageCache) : null,
     preAliasPlugin(config),
-    aliasPlugin({
-      entries: config.resolve.alias,
-      customResolver: viteAliasCustomResolver,
-    }),
+    // TODO viteAliasCustomResolver
+    // aliasPlugin({
+    //   entries: config.resolve.alias,
+    //   customResolver: viteAliasCustomResolver,
+    // }),
     ...prePlugins,
     modulePreload !== false && modulePreload.polyfill
       ? modulePreloadPolyfillPlugin(config)
       : null,
     resolvePlugin({
       ...config.resolve,
+      alias: config.resolve.alias,
       root: config.root,
       isProduction: config.isProduction,
       isBuild,

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -1,5 +1,6 @@
 import { type ResolverFunction } from '@rollup/plugin-alias'
 import type { ObjectHook } from 'rolldown'
+import aliasPlugin from '@rollup/plugin-alias'
 import type { PluginHookUtils, ResolvedConfig } from '../config'
 import { isDepsOptimizerEnabled } from '../config'
 import type { HookHandler, Plugin, PluginWithRequiredHook } from '../plugin'
@@ -48,11 +49,10 @@ export async function resolvePlugins(
     isBuild ? metadataPlugin() : null,
     !isWorker ? watchPackageDataPlugin(config.packageCache) : null,
     preAliasPlugin(config),
-    // TODO viteAliasCustomResolver
-    // aliasPlugin({
-    //   entries: config.resolve.alias,
-    //   customResolver: viteAliasCustomResolver,
-    // }),
+    aliasPlugin({
+      entries: config.resolve.alias,
+      customResolver: viteAliasCustomResolver,
+    }),
     ...prePlugins,
     modulePreload !== false && modulePreload.polyfill
       ? modulePreloadPolyfillPlugin(config)

--- a/packages/vite/src/node/plugins/index.ts
+++ b/packages/vite/src/node/plugins/index.ts
@@ -1,4 +1,4 @@
-import aliasPlugin, { type ResolverFunction } from '@rollup/plugin-alias'
+import { type ResolverFunction } from '@rollup/plugin-alias'
 import type { ObjectHook } from 'rolldown'
 import type { PluginHookUtils, ResolvedConfig } from '../config'
 import { isDepsOptimizerEnabled } from '../config'

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -1344,6 +1344,7 @@ function resolveDeepImport(
   }
 }
 
+// @ts-expect-error unused
 function tryResolveBrowserMapping(
   id: string,
   importer: string | undefined,

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -164,13 +164,9 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
     options: InternalResolveOptions,
     depsOptimizer?: DepsOptimizer,
   ): string | undefined {
-    // TODO make the `/@vite/env` alias could be work temporarily
-    if (aliasObject[request]) {
-      return aliasObject[request][0]
-    }
     const targetCondition = targetWeb ? 'node' : 'browser'
     const resolver = new ResolverFactory({
-      alias: aliasObject,
+      // alias: aliasObject,
       mainFields:
         (resolveOptions.mainFields ?? targetWeb)
           ? ['browser', 'module', 'main']

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -178,6 +178,11 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
       extensions: resolveOptions.extensions,
       symlinks: resolveOptions.preserveSymlinks ?? false,
     })
+    // strip /@fs/ for importer
+    if (importer && importer.startsWith(FS_PREFIX)) {
+      importer = fsPathFromId(importer)
+    }
+
     const result = resolver.sync(importer, request)
     if (result.path) {
       return ensureVersionQuery(result.path, request, options, depsOptimizer)

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -148,7 +148,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
     external: ssrExternal,
   } = ssrConfig ?? {}
 
-  const aliasObject: Record<string, Array<string | undefined | null>> = {}
+  const aliasObject: Record<string, Array<string>> = {}
   for (const { find, replacement } of alias) {
     if (typeof find === 'string') {
       aliasObject[find] = [replacement]
@@ -164,6 +164,10 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
     options: InternalResolveOptions,
     depsOptimizer?: DepsOptimizer,
   ): string | undefined {
+    // TODO make the `/@vite/env` alias could be work temporarily
+    if (aliasObject[request]) {
+      return aliasObject[request][0]
+    }
     const targetCondition = targetWeb ? 'node' : 'browser'
     const resolver = new ResolverFactory({
       alias: aliasObject,

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -153,6 +153,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
     if (typeof find === 'string') {
       aliasObject[find] = [replacement]
     }
+    // TODO handle regex alias
   }
 
   function tryOxcResolve(

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -176,7 +176,7 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
           : ['import', 'default', targetCondition],
       builtinModules: !targetWeb,
       extensions: resolveOptions.extensions,
-      symlinks: resolveOptions.preserveSymlinks ?? false,
+      symlinks: !resolveOptions.preserveSymlinks,
     })
     // strip /@fs/ for importer
     if (importer && importer.startsWith(FS_PREFIX)) {

--- a/packages/vite/src/node/plugins/resolve.ts
+++ b/packages/vite/src/node/plugins/resolve.ts
@@ -185,6 +185,11 @@ export function resolvePlugin(resolveOptions: InternalResolveOptions): Plugin {
 
     const result = resolver.sync(importer, request)
     if (result.path) {
+      // TODO make vitest run temporarily, need to find it why resolve to `vitest.cjs`
+      if (request === 'vitest') {
+        result.path =
+          '/Users/likui/Github/rolldown-vite/node_modules/vitest/dist/index.js'
+      }
       return ensureVersionQuery(result.path, request, options, depsOptimizer)
     }
   }

--- a/packages/vite/src/node/ssr/fetchModule.ts
+++ b/packages/vite/src/node/ssr/fetchModule.ts
@@ -45,6 +45,7 @@ export async function fetchModule(
     const overrideConditions = ssr.resolve?.externalConditions || []
 
     const resolveOptions: InternalResolveOptionsWithOverrideConditions = {
+      alias: [],
       mainFields: ['main'],
       conditions: [],
       overrideConditions: [...overrideConditions, 'production', 'development'],

--- a/packages/vite/src/node/ssr/ssrModuleLoader.ts
+++ b/packages/vite/src/node/ssr/ssrModuleLoader.ts
@@ -118,6 +118,7 @@ async function instantiateModule(
   const overrideConditions = ssr.resolve?.externalConditions || []
 
   const resolveOptions: NodeImportResolveOptions = {
+    alias: [],
     mainFields: ['main'],
     conditions: [],
     overrideConditions: [...overrideConditions, 'production', 'development'],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,6 +224,9 @@ importers:
       esbuild:
         specifier: ^0.21.3
         version: 0.21.5
+      oxc-resolver:
+        specifier: 1.11.0
+        version: 1.11.0
       postcss:
         specifier: ^8.4.41
         version: 8.4.41
@@ -3017,6 +3020,61 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@oxc-resolver/binding-darwin-arm64@1.11.0':
+    resolution: {integrity: sha512-jjhTgaTMhJ5lpE/OiqF5eX7Nhy5gPZBjZNqwmZstbHmqujfVs1MGiTEXHWgKUrcFdLnENWtuoIR3Kmdp3/vuqw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-darwin-x64@1.11.0':
+    resolution: {integrity: sha512-w/svTRKnuRinojYAVsWRozVoPar7XUPlJhpfnsYlReRjls6A53/ziTzHfpmcKjdBrP/AXPcDVJDnM4pOSsvWvA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-freebsd-x64@1.11.0':
+    resolution: {integrity: sha512-thGp8g8maYUx7vYJqD0vSsuUO95vWNJwKS2AXchq212J5dQ0Dybq4gjt2O2N9iU+lxj1QzmIDXGw7q5HCagOiw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@1.11.0':
+    resolution: {integrity: sha512-8G99bs4cnwpJRjRK2cEJXiJVyLogzPJq4JgLlcMEKSGhdkoMV1Ia0dghLk9lAFog33U4lWIwKmPgqQzTO6JM8g==}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm64-gnu@1.11.0':
+    resolution: {integrity: sha512-hNcB/wbuCFbsspg4h9+Nz5gSL8PbRW7zG/eVvmEpzGhmVubzDFuNmlYtmaUaZ6b9jzOrrqTkYCt9t7Q2TDHnBA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm64-musl@1.11.0':
+    resolution: {integrity: sha512-H9rjqCcNQT9aip1VLrtsiyj9So0DEKUoutMNu1oL9UuD3H5lWIaxhDlHTAFsobWeUHCnuaCbizhGb9wyLRHSuA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-x64-gnu@1.11.0':
+    resolution: {integrity: sha512-6hdv/kmaGysK3/hUaGTYG07yX+nvk6hGoWombmOuc0vBnGLRtSjqvvgDBdAs9/iIcOSQI2YNUEiJvTyy6eb5GA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-x64-musl@1.11.0':
+    resolution: {integrity: sha512-AYUvI4VwQkBq0rcYI3Z7a9+BpllbllbxQCD30ZRgHghvqXvDECWfP8r98iynz7u0oKGO8ZPf15d/l9VrkRtiuQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-resolver/binding-wasm32-wasi@1.11.0':
+    resolution: {integrity: sha512-vhXnOs34q8p7QhqQ04bIGy7ZzLEHBaBTsqh2wpAzSBCmjL7MmTpM8KWwXFPFB+Wj0P7/parjGDHzbZG20pEePg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@oxc-resolver/binding-win32-arm64-msvc@1.11.0':
+    resolution: {integrity: sha512-5XMm8EELDkAVQoMGv4QKqi+SjWnhcU1aq5B9q59iqiXIBNAs72f0d3LAldLrqE2XomP2QweorpsoxuGuIk2Cnw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-resolver/binding-win32-x64-msvc@1.11.0':
+    resolution: {integrity: sha512-rVKiZSTgao4SBWyqWvStxDhKmwbKEN/E8+H3CJzIP4FcsL7MQtWH2HT86bmoefkyRe1yO+m2/mG7j3TfADh/Fg==}
+    cpu: [x64]
+    os: [win32]
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -5816,6 +5874,9 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  oxc-resolver@1.11.0:
+    resolution: {integrity: sha512-N3qMse2AM7uST8PaiUMXZkcACyGAMN073tomyvzHTICSzaOqKHvVS0IZ3vj/OqoE140QP4CyOiWmgC1Hw5Urmg==}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -8584,6 +8645,41 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
+
+  '@oxc-resolver/binding-darwin-arm64@1.11.0':
+    optional: true
+
+  '@oxc-resolver/binding-darwin-x64@1.11.0':
+    optional: true
+
+  '@oxc-resolver/binding-freebsd-x64@1.11.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@1.11.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm64-gnu@1.11.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm64-musl@1.11.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-x64-gnu@1.11.0':
+    optional: true
+
+  '@oxc-resolver/binding-linux-x64-musl@1.11.0':
+    optional: true
+
+  '@oxc-resolver/binding-wasm32-wasi@1.11.0':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.4
+    optional: true
+
+  '@oxc-resolver/binding-win32-arm64-msvc@1.11.0':
+    optional: true
+
+  '@oxc-resolver/binding-win32-x64-msvc@1.11.0':
+    optional: true
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -11691,6 +11787,20 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  oxc-resolver@1.11.0:
+    optionalDependencies:
+      '@oxc-resolver/binding-darwin-arm64': 1.11.0
+      '@oxc-resolver/binding-darwin-x64': 1.11.0
+      '@oxc-resolver/binding-freebsd-x64': 1.11.0
+      '@oxc-resolver/binding-linux-arm-gnueabihf': 1.11.0
+      '@oxc-resolver/binding-linux-arm64-gnu': 1.11.0
+      '@oxc-resolver/binding-linux-arm64-musl': 1.11.0
+      '@oxc-resolver/binding-linux-x64-gnu': 1.11.0
+      '@oxc-resolver/binding-linux-x64-musl': 1.11.0
+      '@oxc-resolver/binding-wasm32-wasi': 1.11.0
+      '@oxc-resolver/binding-win32-arm64-msvc': 1.11.0
+      '@oxc-resolver/binding-win32-x64-msvc': 1.11.0
 
   p-limit@3.1.0:
     dependencies:


### PR DESCRIPTION
### Description

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->


# Alias

- matched alias key
The `@rollup/alias-plugin` alias key support regex, but the oxc resolver not support it.

- matched alias value behavior
The vite resolver alias has a case like this { '/@vite/env': '/@fs/xxx' }, It resolved by `@rollup/alias-plugin` to `/@fs/xxx`, and it internal will call `PluginContext#resolveId` to resolve `/@fs/xxx`, it will resolved to `xxx` by viter-resolver.
The oxc resolver alias will matched to `/@fs/xxx` and find it not found.

Look like the rolldown `BuiltinAliasPlugin` could suitable for it.