### PR TITLE
fix: disable vite log filter

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -1037,10 +1037,10 @@ export function resolveBuildOutputs(
 }
 
 const warningIgnoreList = [`CIRCULAR_DEPENDENCY`, `THIS_IS_UNDEFINED`]
-const dynamicImportWarningIgnoreList = [
-  `Unsupported expression`,
-  `statically analyzed`,
-]
+// const dynamicImportWarningIgnoreList = [
+//   `Unsupported expression`,
+//   `statically analyzed`,
+// ]
 
 function clearLine() {
   const tty = process.stdout.isTTY && !process.env.CI
@@ -1065,41 +1065,41 @@ export function onRollupWarning(
     }
 
     if (typeof warning === 'object') {
-      if (warning.code === 'UNRESOLVED_IMPORT') {
-        const id = warning.id
-        const exporter = warning.exporter
-        // throw unless it's commonjs external...
-        if (!id || !id.endsWith('?commonjs-external')) {
-          throw new Error(
-            `[vite]: Rollup failed to resolve import "${exporter}" from "${id}".\n` +
-              `This is most likely unintended because it can break your application at runtime.\n` +
-              `If you do want to externalize this module explicitly add it to\n` +
-              `\`build.rollupOptions.external\``,
-          )
-        }
-      }
+      // if (warning.code === 'UNRESOLVED_IMPORT') {
+      //   const id = warning.id
+      //   const exporter = warning.exporter
+      //   // throw unless it's commonjs external...
+      //   if (!id || !id.endsWith('?commonjs-external')) {
+      //     throw new Error(
+      //       `[vite]: Rollup failed to resolve import "${exporter}" from "${id}".\n` +
+      //         `This is most likely unintended because it can break your application at runtime.\n` +
+      //         `If you do want to externalize this module explicitly add it to\n` +
+      //         `\`build.rollupOptions.external\``,
+      //     )
+      //   }
+      // }
 
-      if (
-        warning.plugin === 'rollup-plugin-dynamic-import-variables' &&
-        dynamicImportWarningIgnoreList.some((msg) =>
-          warning.message.includes(msg),
-        )
-      ) {
-        return
-      }
+      // if (
+      //   warning.plugin === 'rollup-plugin-dynamic-import-variables' &&
+      //   dynamicImportWarningIgnoreList.some((msg) =>
+      //     warning.message.includes(msg),
+      //   )
+      // ) {
+      //   return
+      // }
 
       if (warningIgnoreList.includes(warning.code!)) {
         return
       }
 
-      if (warning.code === 'PLUGIN_WARNING') {
-        environment.logger.warn(
-          `${colors.bold(
-            colors.yellow(`[plugin:${warning.plugin}]`),
-          )} ${colors.yellow(warning.message)}`,
-        )
-        return
-      }
+      // if (warning.code === 'PLUGIN_WARNING') {
+      //   environment.logger.warn(
+      //     `${colors.bold(
+      //       colors.yellow(`[plugin:${warning.plugin}]`),
+      //     )} ${colors.yellow(warning.message)}`,
+      //   )
+      //   return
+      // }
     }
 
     warn(warnLog)


### PR DESCRIPTION
### Description
1. rolldown `warnLog` only has `code` and `message` two field, so disable other log filter that use unsupported 
field, here is an example : 
```bash
warnLog:  {
  code: 'UNRESOLVED_IMPORT',
  message: '\x1B[33m[UNRESOLVED_IMPORT] Warning:\x1B[0m "./src/main.jsx" is imported by "index.html", but could not be resolved – treating it as an external dependency.\n'
}
Error: [vite]: Rollup failed to resolve import "undefined" from "undefined".
```
<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
