### PR TITLE
chore: enable continuous release under rolldown-vite

### DIFF
--- a/.github/workflows/publish-commit.yml
+++ b/.github/workflows/publish-commit.yml
@@ -7,13 +7,13 @@ env:
 on:
   push:
     branches:
-      - main
+      - rolldown-v6
   issue_comment:
     types: [created]
 
 jobs:
   build:
-    if: github.repository == 'vitejs/vite' && (github.event_name == 'push' || github.event.issue.pull_request && startsWith(github.event.comment.body, '/pkg-pr-new'))
+    if: github.repository == 'rolldown/vite' && (github.event_name == 'push' || github.event.issue.pull_request && startsWith(github.event.comment.body, '/pkg-pr-new'))
     runs-on: ubuntu-latest
 
     steps:

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "tsx": "^4.19.1",
     "typescript": "^5.6.2",
     "typescript-eslint": "^8.8.0",
-    "vite": "workspace:*",
+    "vite": "workspace:rolldown-vite@*",
     "vitest": "^2.1.2"
   },
   "simple-git-hooks": {
@@ -99,7 +99,7 @@
   "packageManager": "pnpm@9.12.0",
   "pnpm": {
     "overrides": {
-      "vite": "workspace:*"
+      "vite": "workspace:rolldown-vite@*"
     },
     "patchedDependencies": {
       "acorn@8.12.1": "patches/acorn@8.12.1.patch",

--- a/packages/plugin-legacy/package.json
+++ b/packages/plugin-legacy/package.json
@@ -57,6 +57,6 @@
     "acorn": "^8.12.1",
     "picocolors": "^1.1.0",
     "unbuild": "^2.0.0",
-    "vite": "workspace:*"
+    "vite": "workspace:rolldown-vite@*"
   }
 }

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "vite",
+  "name": "rolldown-vite",
   "version": "6.0.0-beta.2",
   "type": "module",
   "license": "MIT",
   "author": "Evan You",
-  "description": "Native-ESM powered web dev build tool",
+  "description": "Vite on Rolldown preview",
   "bin": {
     "vite": "bin/vite.js"
   },
@@ -62,11 +62,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vitejs/vite.git",
+    "url": "git+https://github.com/rolldown/vite.git",
     "directory": "packages/vite"
   },
   "bugs": {
-    "url": "https://github.com/vitejs/vite/issues"
+    "url": "https://github.com/rolldown/vite/issues"
   },
   "homepage": "https://vite.dev",
   "funding": "https://github.com/vitejs/vite?sponsor=1",

--- a/playground/config/__tests__/config.spec.ts
+++ b/playground/config/__tests__/config.spec.ts
@@ -42,7 +42,7 @@ it.runIf(isImportAttributesSupported)(
     )
     expect(config).toMatchInlineSnapshot(`
       {
-        "jsonValue": "vite",
+        "jsonValue": "rolldown-vite",
       }
     `)
   },

--- a/playground/external/package.json
+++ b/playground/external/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "slash3": "npm:slash@^3.0.0",
     "slash5": "npm:slash@^5.1.0",
-    "vite": "workspace:*",
+    "vite": "workspace:rolldown-vite@*",
     "vue": "^3.5.11",
     "vue32": "npm:vue@~3.2.0"
   }

--- a/playground/legacy/package.json
+++ b/playground/legacy/package.json
@@ -15,7 +15,7 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "vite": "workspace:*",
+    "vite": "workspace:rolldown-vite@*",
     "@vitejs/plugin-legacy": "workspace:*",
     "express": "^4.21.0",
     "terser": "^5.34.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  vite: workspace:*
+  vite: workspace:rolldown-vite@*
 
 patchedDependencies:
   acorn@8.12.1:
@@ -134,7 +134,7 @@ importers:
         specifier: ^8.8.0
         version: 8.8.0(eslint@9.12.0(jiti@1.21.0))(typescript@5.6.2)
       vite:
-        specifier: workspace:*
+        specifier: workspace:rolldown-vite@*
         version: link:packages/vite
       vitest:
         specifier: ^2.1.2
@@ -222,7 +222,7 @@ importers:
         specifier: ^2.0.0
         version: 2.0.0(sass@1.79.4)(typescript@5.6.2)
       vite:
-        specifier: workspace:*
+        specifier: workspace:rolldown-vite@*
         version: link:../vite
 
   packages/vite:
@@ -719,7 +719,7 @@ importers:
         specifier: npm:slash@^5.1.0
         version: slash@5.1.0
       vite:
-        specifier: workspace:*
+        specifier: workspace:rolldown-vite@*
         version: link:../../packages/vite
       vue:
         specifier: ^3.5.11
@@ -815,7 +815,7 @@ importers:
         specifier: ^5.34.1
         version: 5.34.1
       vite:
-        specifier: workspace:*
+        specifier: workspace:rolldown-vite@*
         version: link:../../packages/vite
 
   playground/lib:
@@ -3602,7 +3602,7 @@ packages:
     resolution: {integrity: sha512-nY9IwH12qeiJqumTCLJLE7IiNx7HZ39cbHaysEUd+Myvbz9KAqd2yq+U01Kab1R/H1BmiyM2ShTYlNH32Fzo3A==}
     engines: {node: ^18.0.0 || >=20.0.0}
     peerDependencies:
-      vite: workspace:*
+      vite: workspace:rolldown-vite@*
       vue: ^3.2.25
 
   '@vitejs/release-scripts@1.3.2':
@@ -3856,7 +3856,7 @@ packages:
     resolution: {integrity: sha512-ExElkCGMS13JAJy+812fw1aCv2QO/LBK6CyO4WOPAzLTmve50gydOlWhgdBJPx2ztbADUq3JVI0C5U+bShaeEA==}
     peerDependencies:
       msw: ^2.3.5
-      vite: workspace:*
+      vite: workspace:rolldown-vite@*
     peerDependenciesMeta:
       msw:
         optional: true


### PR DESCRIPTION
In order to publish the package the name in `packages/vite/package.json` is changed to `rolldown-vite`.

We'll need to remember to revert this when we eventually move this work over to the main `vitejs/vite` repo.