### PR TITLE
fix(css): inline css insert for single quote `use strict`

### DIFF
--- a/packages/vite/src/node/plugins/css.ts
+++ b/packages/vite/src/node/plugins/css.ts
@@ -880,12 +880,21 @@ export function cssPostPlugin(config: ResolvedConfig): RolldownPlugin {
               `document.head.appendChild(${style});`
             let injectionPoint
             const wrapIdx = code.indexOf('System.register')
+            const singleQuotesUseStruct = `'use strict';`
+            const doubleQuotesUseStruct = `"use strict";`
             if (wrapIdx >= 0) {
               const executeFnStart = code.indexOf('execute:', wrapIdx)
               injectionPoint = code.indexOf('{', executeFnStart) + 1
+            } else if (code.includes(singleQuotesUseStruct)) {
+              injectionPoint =
+                code.indexOf(singleQuotesUseStruct) +
+                singleQuotesUseStruct.length
+            } else if (code.includes(doubleQuotesUseStruct)) {
+              injectionPoint =
+                code.indexOf(doubleQuotesUseStruct) +
+                doubleQuotesUseStruct.length
             } else {
-              const insertMark = "'use strict';"
-              injectionPoint = code.indexOf(insertMark) + insertMark.length
+              throw new Error('Not found injection point for inlined CSS')
             }
             s ||= new MagicString(code)
             s.appendRight(injectionPoint, injectCode)


### PR DESCRIPTION
### Description

I meet the error when enable the lib test at vite-plugin-vue. ref https://github.com/rolldown/vite-plugin-vue/actions/runs/12293389227/job/34305975962?pr=1
```
[plugin vite:esbuild-transpile] index.js.umd.cjs:1:16
Error: Transform failed with 1 error:
index.js.umd.cjs:1:16: ERROR: Expected ")" but found "__vite_style__"
Expected ")" but found "__vite_style__"
1  |  (function(glvar __vite_style__ = document.createElement('style');__vite_style__.textContent = ".card{padding:4rem}\n/*$vite$:1*/";document.head.appendChild(__vite_style__);obal, factory) {
   |                  ^
2  |    typeof exports === 'object' && typeof module !== 'undefined' ?  factory(exports) :
3  |    typeof define === 'function' && define.amd ? define([exports], factory) :
```

I debugger it and found the rolldown output doubleQuotesUseStruct at umd format, it make insert position error. Here i add a doubleQuotesUseStruct test and also preserve singleQuotesUseStruct to get more compatible, avoiding the rolldown of unintentional changes at future.

Here also add a specific error if not found insert position, it is more friendly to maintainer if something unexpected happened.

<!-- What is this PR solving? Write a clear description or reference the issues it solves (e.g. `fixes #123`). What other alternatives have you explored? Are there any parts you think require more attention from reviewers? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
