### PR TITLE
fix: allow chunk.modules mutation on js side

### DIFF
--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -1350,6 +1350,7 @@ function injectChunkMetadata(
     chunkMetadataMap.set(key, {
       importedAssets: new Set(),
       importedCss: new Set(),
+      // NOTE: adding this as a workaround for now ideally we'd want to remove this workaround
       // use shared `chunk.modules` object
       // to allow mutation on js side plugins
       __modules: chunk.modules,

--- a/packages/vite/src/node/build.ts
+++ b/packages/vite/src/node/build.ts
@@ -1350,9 +1350,17 @@ function injectChunkMetadata(
     chunkMetadataMap.set(key, {
       importedAssets: new Set(),
       importedCss: new Set(),
+      // use shared `chunk.modules` object
+      // to allow mutation on js side plugins
+      __modules: chunk.modules,
     })
   }
   chunk.viteMetadata = chunkMetadataMap.get(key)
+  Object.defineProperty(chunk, 'modules', {
+    get() {
+      return chunk.viteMetadata!.__modules
+    },
+  })
 }
 
 function injectEnvironmentInContext<Context extends MinimalPluginContext>(

--- a/packages/vite/types/metadata.d.ts
+++ b/packages/vite/types/metadata.d.ts
@@ -1,6 +1,7 @@
 export interface ChunkMetadata {
   importedAssets: Set<string>
   importedCss: Set<string>
+  __modules: any
 }
 
 declare module 'rolldown' {


### PR DESCRIPTION
### Description

I added a quick and dirty workaround for `chunk.modules` mutation. I tested on unocss and this seems to fix some tests ~(but not all :cry:).~ (EDIT: it turned out other test failure is due to oxc transform https://github.com/oxc-project/oxc/issues/9192 and technically unocss side is broken https://github.com/unocss/unocss/issues/4436).

Probably this isn't good for the long run (considering rolldown level css support?), but if this trick can save ecosystem for the time being, it might be worth it. 